### PR TITLE
Call callback now run first

### DIFF
--- a/Pharos/Classes/Observable/Subject.swift
+++ b/Pharos/Classes/Observable/Subject.swift
@@ -16,10 +16,8 @@ public final class Subject<Wrapped>: BindableObservable<Wrapped> {
             _wrappedValue
         }
         set {
-            let oldValue = _wrappedValue
-            _wrappedValue = newValue
             relay(
-                changes: Changes(old: oldValue, new: newValue, source: self),
+                changes: Changes(old: _wrappedValue, new: newValue, source: self),
                 context: PharosContext()
             )
         }

--- a/Pharos/Classes/Relay/BindableKVOObservable.swift
+++ b/Pharos/Classes/Relay/BindableKVOObservable.swift
@@ -46,8 +46,8 @@ final class BindableKVOObservable<Object: NSObject, Observed>: BindableObservabl
             super.superRelay(changes, context)
             self.recentSource = .none
         case .external:
-            super.superRelay(changes, context)
             super.callCallback(changes)
+            super.superRelay(changes, context)
         case .none:
             return
         }

--- a/Pharos/Classes/Relay/BindableObservable.swift
+++ b/Pharos/Classes/Relay/BindableObservable.swift
@@ -34,8 +34,8 @@ open class BindableObservable<State>: RootObservable<State> {
     }
     
     override func relay(changes: Changes<State>, context: PharosContext) {
-        superRelay(changes, context)
         callCallback(changes)
+        superRelay(changes, context)
     }
     
     public override func relayChanges(to relay: BindableObservable<State>) -> Observed<State> {


### PR DESCRIPTION
- Move callback run to be first before relay changes to another relay so on another relay, previous relay is already updated