### PR TITLE
Remove test dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,44 +6,8 @@
         "repositoryURL": "https://github.com/hainayanda/Chary.git",
         "state": {
           "branch": null,
-          "revision": "fd457cc09d2e7bd8ab27677550afdb7d15830b9e",
-          "version": "1.0.1"
-        }
-      },
-      {
-        "package": "CwlCatchException",
-        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
-        "state": {
-          "branch": null,
-          "revision": "f809deb30dc5c9d9b78c872e553261a61177721a",
-          "version": "2.0.0"
-        }
-      },
-      {
-        "package": "CwlPreconditionTesting",
-        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
-        "state": {
-          "branch": null,
-          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
-          "version": "2.1.0"
-        }
-      },
-      {
-        "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble.git",
-        "state": {
-          "branch": null,
-          "revision": "1f3bde57bde12f5e7b07909848c071e9b73d6edc",
-          "version": "10.0.0"
-        }
-      },
-      {
-        "package": "Quick",
-        "repositoryURL": "https://github.com/Quick/Quick.git",
-        "state": {
-          "branch": null,
-          "revision": "f9d519828bb03dfc8125467d8f7b93131951124c",
-          "version": "5.0.1"
+          "revision": "afcddefdd56cbd6df198382bd2c65c7998f8d240",
+          "version": "1.0.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,9 +17,10 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/hainayanda/Chary.git", from: "1.0.1"),
-        .package(url: "https://github.com/Quick/Quick.git", from: "5.0.1"),
-        .package(url: "https://github.com/Quick/Nimble.git", from: "10.0.0")
+        .package(url: "https://github.com/hainayanda/Chary.git", from: "1.0.2"),
+        // uncomment code below to run test
+//        .package(url: "https://github.com/Quick/Quick.git", from: "5.0.1"),
+//        .package(url: "https://github.com/Quick/Nimble.git", from: "10.0.0")
     ],
     targets: [
         .target(
@@ -27,13 +28,14 @@ let package = Package(
             dependencies: ["Chary"],
             path: "Pharos/Classes"
         ),
-        .testTarget(
-            name: "PharosTests",
-            dependencies: [
-                "Pharos", "Quick", "Nimble"
-            ],
-            path: "Example/Tests",
-            exclude: ["Info.plist"]
-        )
+        // uncomment code below to run test
+//        .testTarget(
+//            name: "PharosTests",
+//            dependencies: [
+//                "Pharos", "Quick", "Nimble"
+//            ],
+//            path: "Example/Tests",
+//            exclude: ["Info.plist"]
+//        )
     ]
 )


### PR DESCRIPTION
Since some projects will have different Quick and Nimble versions, and it shouldn't include in the distribution, it is now removed from dependency in Swift Package Manager version.